### PR TITLE
Add support for `axios.create`

### DIFF
--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -19,6 +19,7 @@ class MockAxios {
   public post:SpyFn = jest.fn(this.newReq.bind(this))
   public put:SpyFn = jest.fn(this.newReq.bind(this))
   public delete:SpyFn = jest.fn(this.newReq.bind(this))
+  public create:MockAxios = jest.fn(() => this)
 
   private newReq():any {
     let promise = new SyncPromise()


### PR DESCRIPTION
Support for [`axios.create`](https://github.com/axios/axios#axioscreateconfig) missing.