### PR TITLE
Add support for `axios.all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Because it works synchronously, meaning that your tests will be easier to write,
 ## Can it be used with Jasmine/Mocha?
 Unfortunately *out of the box* this mock works only with [Jest](https://facebook.github.io/jest/).
 
-However, if you look at the [source code](https://github.com/knee-cola/jest-mock-axios/blob/master/lib/mock-axios.ts), you can see that it uses Jest only to define spies (for methods `post`, `get`, `put`, `delete`, `create`). This means that it can easily be modified to use any other testing framework - go to [GitHub](https://github.com/knee-cola/jest-mock-axios), clone it, modify it, play with it :)
+However, if you look at the [source code](https://github.com/knee-cola/jest-mock-axios/blob/master/lib/mock-axios.ts), you can see that it uses Jest only to define spies (for methods `post`, `get`, `put`, `delete`, `create`, `all`). This means that it can easily be modified to use any other testing framework - go to [GitHub](https://github.com/knee-cola/jest-mock-axios), clone it, modify it, play with it :)
 
 # What's in this document?
 * [Installation](#installation)
@@ -113,7 +113,7 @@ export default UppercaseProxy;
 At the bottom of this page you can find [additional examples](#additional-examples).
 
 # Axios mock API
-In addition to standard Axios methods (`post`, `get`, `put`, `delete`, `create`), which are exposed as spies, Axios mock has three additional public methods, which are intended to facilitate mocking:
+In addition to standard Axios methods (`post`, `get`, `put`, `delete`, `create`, `all`), which are exposed as spies, Axios mock has three additional public methods, which are intended to facilitate mocking:
 * `mockResponse` - simulates a server (web service) response
 * `mockError` - simulates a (network/server) error 
 * `lastReqGet` - returns extended info about the most recent request
@@ -183,7 +183,7 @@ let requestInfo = {
 ## axios.lastPromiseGet()
 `lastPromiseGet` method returns a promise given when the most recent server request was made. The returned value can be used to pinpoint exact server request we wish to resolve (the value is passed as the second param of `mockResponse` or `mockError` methods).
 
-The promise object returned by this function corresponds to the one returned by `post`, `get`, `put` or `delete` method inside the code we wish to test.
+The promise object returned by this function corresponds to the one returned by `post`, `get`, `put`, `delete` or `all` method inside the code we wish to test.
 
 
 [Additional examples](#additional-examples) at the end of this document illustrate how this method can be used.

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -21,6 +21,7 @@ type AxiosAPI = {
     post?:SpyFn;
     put?:SpyFn;
     delete?:SpyFn;
+    all?:SpyFn;
     create?:SpyFn;
 };
 

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -30,6 +30,7 @@ MockAxios.get = jest.fn(_newReq);
 MockAxios.post = jest.fn(_newReq);
 MockAxios.put = jest.fn(_newReq);
 MockAxios.delete = jest.fn(_newReq);
+MockAxios.all = jest.fn(_newReq);
 MockAxios.create = jest.fn(() => MockAxios);
 
 MockAxios.popPromise = (promise?:SyncPromise) => {
@@ -127,6 +128,7 @@ MockAxios.reset = () => {
   MockAxios.post.mockClear();
   MockAxios.put.mockClear();
   MockAxios.delete.mockClear();
+  MockAxios.all.mockClear();
 }
 
 // this is a singletone object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-mock-axios",
-  "version": "2.1.11",
+  "version": "2.2.0",
   "description": "Axios mock for Jest",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -26,6 +26,9 @@ describe('MockAxios', () => {
     it("`create` should return reference to MockAxios itself", () => {
         expect(MockAxios.create()).toBe(MockAxios);
     });
+    it("`all` should return reference to MockAxios itself", () => {
+        expect(MockAxios.all()).toBe(MockAxios);
+    });
 
     // mockResponse - Simulate a server response, (optionaly) with the given data
     it("`mockResponse` should resolve the given promise with the provided response", () => {
@@ -237,11 +240,13 @@ describe('MockAxios', () => {
         MockAxios.get();
         MockAxios.put();
         MockAxios.delete();
+        MockAxios.all();
 
         expect(MockAxios.post).toHaveBeenCalled();
         expect(MockAxios.get).toHaveBeenCalled();
         expect(MockAxios.put).toHaveBeenCalled();
         expect(MockAxios.delete).toHaveBeenCalled();
+        expect(MockAxios.all).toHaveBeenCalled();
 
         MockAxios.reset();
 
@@ -249,5 +254,6 @@ describe('MockAxios', () => {
         expect(MockAxios.get).not.toHaveBeenCalled();
         expect(MockAxios.put).not.toHaveBeenCalled();
         expect(MockAxios.delete).not.toHaveBeenCalled();
+        expect(MockAxios.all).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Added support for `axios.all`.

Similar to #11 and #12.