### PR TITLE
Add jest.Mock to AxiosMockType interface

### DIFF
--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -140,4 +140,4 @@ export interface AxiosMockQueueItem {
  * Axios object can be called like a function,
  * that's why we're defining it as a spy
  */
-export type AxiosMockType = AxiosFn & AxiosAPI & AxiosMockAPI;
+export type AxiosMockType = AxiosFn & AxiosAPI & AxiosMockAPI & jest.Mock;

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -8,19 +8,12 @@ export interface HttpResponse {
     config?: object;
 }
 
-export type AnyFunction = (...args: any[]) => any;
-
-// spy is a function which extends an object (it has static methods and properties)
-export type SpyFn = AnyFunction & { mockClear: AnyFunction };
-
-export type AxiosFn = (...args: any[]) => SpyFn;
-
 interface Interceptors {
     request: {
-        use: SpyFn;
+        use: jest.Mock<number, [any?, any?]>;
     };
     response: {
-        use: SpyFn;
+        use: jest.Mock<number, [any?, any?]>;
     };
 }
 
@@ -38,7 +31,7 @@ export interface AxiosAPI {
     head: jest.Mock<SyncPromise, [string?, any?, any?]>;
     options: jest.Mock<SyncPromise, [string?, any?, any?]>;
     request: jest.Mock<SyncPromise, [any?]>;
-    all: SpyFn;
+    all: jest.Mock<Promise<any>, [any]>;
     create: jest.Mock<AxiosMockType, []>;
     interceptors: Interceptors;
     defaults: AxiosDefaults;
@@ -140,4 +133,4 @@ export interface AxiosMockQueueItem {
  * Axios object can be called like a function,
  * that's why we're defining it as a spy
  */
-export type AxiosMockType = AxiosFn & AxiosAPI & AxiosMockAPI & jest.Mock;
+export type AxiosMockType = AxiosAPI & AxiosMockAPI & jest.Mock<SyncPromise, [any?]>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-mock-axios",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This enables the default methods/properties when using Axios directly (e.g.: `axios(config)`).

We hit a point where we needed to check the arguments passed to the calls to a direct call of axios (`axios.mock.calls`), and we realized these methods and properties were missing. It would be nice to have all the power of the default jest mock functions.


