### PR TITLE
Add mockResponseFor & getReqMatching

### DIFF
--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -71,6 +71,19 @@ export interface AxiosMockAPI {
         silentMode?: boolean,
     ) => void;
     /**
+     * Simulate a server response for a specific request, (optionally) with the given data
+     * @param criteria specifies which request should be resolved; it can be just the URL
+     *   or an object containing url and/or method
+     * @param response (optional) response returned by the server
+     * @param silentMode (optional) specifies whether the call should throw an error or
+     *   only fail quietly if no matching request is found.
+     */
+    mockResponseFor: (
+        criteria: string | AxiosMockRequestCriteria,
+        response?: HttpResponse,
+        silentMode?: boolean,
+    ) => void;
+    /**
      * Simulate an error in server request
      * @param error (optional) error object
      * @param queueItem (optional) request promise for which response should be resolved

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -97,6 +97,16 @@ export interface AxiosMockAPI {
      */
     lastReqGet: () => AxiosMockQueueItem;
     /**
+     * Returns request item of the most recent request with the given criteria
+     * Returns undefined if no matching request could be found
+     *
+     * The result can then be used with @see mockResponse; in most cases it is better
+     * to use @see mockResponseFor instead of calling this function yourself
+     *
+     * @param criteria the criteria by which to find the request
+     */
+    getReqMatching: (criteria: AxiosMockRequestCriteria) => AxiosMockQueueItem;
+    /**
      * Returns request item of the most recent request with the given url
      * The url must equal the url given in the 1st parameter when the request was made
      * Returns undefined if no matching request could be found
@@ -124,9 +134,15 @@ export interface AxiosMockAPI {
 
 export interface AxiosMockQueueItem {
     promise: UnresolvedSynchronousPromise<any>;
+    method: string;
     url: string;
     data?: any;
     config?: any;
+}
+
+export interface AxiosMockRequestCriteria {
+    url?: string;
+    method?: string;
 }
 
 /**

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -154,6 +154,23 @@ MockAxios.mockResponse = (
     promise.resolve(response);
 };
 
+MockAxios.mockResponseFor = (
+    criteria: string | AxiosMockRequestCriteria,
+    response?: HttpResponse,
+    silentMode: boolean = false,
+): void => {
+    if (typeof criteria === "string") {
+        criteria = {url: criteria};
+    }
+    const queueItem = MockAxios.getReqMatching(criteria);
+    if (!queueItem && !silentMode) {
+        throw new Error("No request to respond to!");
+    } else if (!queueItem) {
+        return;
+    }
+    MockAxios.mockResponse(response, queueItem, silentMode);
+};
+
 MockAxios.mockError = (
     error: any = {},
     queueItem: SynchronousPromise<any> | AxiosMockQueueItem = null,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -259,6 +259,7 @@ describe("MockAxios", () => {
     });
 
     it("`lastReqGet` should contain config as passed to axios", () => {
+        const method = "post";
         const url = "url";
         const data = { data: "data" };
         const config = { config: "config" };
@@ -270,10 +271,12 @@ describe("MockAxios", () => {
                 ...config,
                 data,
                 url,
+                method,
             },
             data,
             promise,
             url,
+            method,
         });
     });
 
@@ -285,7 +288,16 @@ describe("MockAxios", () => {
         expect(MockAxios.lastPromiseGet()).toBe(lastPromise);
     });
 
-    it("`getReqByUrl should return the most recent request matching the url", () => {
+    it("`getReqMatching` should return the most recent request matching the criteria", () => {
+        const url = "url";
+        MockAxios.delete(url);
+        const promise = MockAxios.delete(url);
+        MockAxios.get(url);
+
+        expect(MockAxios.getReqMatching({url, method: "delete"}).promise).toBe(promise);
+    });
+
+    it("`getReqByUrl` should return the most recent request matching the url", () => {
         const url = "url";
         MockAxios.post(url);
         const lastPromise = MockAxios.post(url);
@@ -293,7 +305,7 @@ describe("MockAxios", () => {
         expect(MockAxios.getReqByUrl(url).promise).toBe(lastPromise);
     });
 
-    it("`getReqByUrl should return undefined if no matching request can be found", () => {
+    it("`getReqByUrl` should return undefined if no matching request can be found", () => {
         const url = "url";
         MockAxios.post();
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -151,12 +151,14 @@ describe("MockAxios", () => {
             await promise;
             expect(thenFn).toHaveBeenCalled();
         });
+    });
 
+    describe("mockResponseFor", () => {
         it("`mockResponseFor` should get the correct request using the shortcut", () => {
             const url = "url";
             const thenFn = jest.fn();
             MockAxios.post(url).then(thenFn);
-            MockAxios.get("otherurl")
+            MockAxios.get("otherurl");
             MockAxios.mockResponseFor(url);
             expect(thenFn).toHaveBeenCalled();
         });
@@ -165,9 +167,24 @@ describe("MockAxios", () => {
             const url = "url";
             const thenFn = jest.fn();
             MockAxios.post(url).then(thenFn);
-            MockAxios.get(url)
+            MockAxios.get(url);
             MockAxios.mockResponseFor({url, method: "post"});
             expect(thenFn).toHaveBeenCalled();
+        });
+
+        it("`mockResponseFor` should throw an error if no matching request can be found and !silentMode", () => {
+            const url = "url";
+            expect(() => MockAxios.mockResponseFor({url, method: "post"})).toThrowError(
+                "No request to respond to!",
+            );
+        });
+
+        it("`mockResponseFor` should not throw an error if no matching request can be found but silentMode", () => {
+            const url = "url";
+            const thenFn = jest.fn();
+            MockAxios.post("otherurl").then(thenFn);
+            expect(() => MockAxios.mockResponseFor({url, method: "post"}, {data: {}}, true)).not.toThrow();
+            expect(thenFn).not.toHaveBeenCalled();
         });
     });
 
@@ -313,6 +330,13 @@ describe("MockAxios", () => {
         MockAxios.get(url);
 
         expect(MockAxios.getReqMatching({url, method: "delete"}).promise).toBe(promise);
+    });
+
+    it("`getReqMatching` should return undefined if no matching request can be found", () => {
+        const url = "url";
+        MockAxios.post();
+
+        expect(MockAxios.getReqMatching({url})).toBeUndefined();
     });
 
     it("`getReqByUrl` should return the most recent request matching the url", () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -151,6 +151,24 @@ describe("MockAxios", () => {
             await promise;
             expect(thenFn).toHaveBeenCalled();
         });
+
+        it("`mockResponseFor` should get the correct request using the shortcut", () => {
+            const url = "url";
+            const thenFn = jest.fn();
+            MockAxios.post(url).then(thenFn);
+            MockAxios.get("otherurl")
+            MockAxios.mockResponseFor(url);
+            expect(thenFn).toHaveBeenCalled();
+        });
+
+        it("`mockResponseFor` should get the correct request", () => {
+            const url = "url";
+            const thenFn = jest.fn();
+            MockAxios.post(url).then(thenFn);
+            MockAxios.get(url)
+            MockAxios.mockResponseFor({url, method: "post"});
+            expect(thenFn).toHaveBeenCalled();
+        });
     });
 
     describe("mockError", () => {


### PR DESCRIPTION
I would have liked to support `params` and `data` in the criteria as well, but, that would have required adding e.g. lodash's isEqual or a similar library as a dependency (for deep object comparison). I tried adding it, but something with the ES module imports was breaking ("is_equal_1.default is not a function" and similar errors no matter which library i tried (`lodash.isequal`, `lodash`, `lodash-es`, `is-equal`)).

closes #42