### PR TITLE
Create MockAxios.queue() and MockAxios.getByMatchUrl(regex) functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ However, if you look at the [source code](https://github.com/knee-cola/jest-mock
   * [axios.mockResponseFor](#axiosmockresponseforcriteria-response-silentmode)
   * [axios.mockError](#axiosmockerrorerr-requestinfo)
   * [axios.lastReqGet](#axioslastreqget)
+  * [axios.getReqByMatchUrl](#axiosgetreqbymatchurl)
   * [axios.lastPromiseGet](#axioslastpromiseget)
   * [axios.reset](#axiosreset)
 * [Additional examples](#additional-examples)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ However, if you look at the [source code](https://github.com/knee-cola/jest-mock
   * [axios.mockResponseFor](#axiosmockresponseforcriteria-response-silentmode)
   * [axios.mockError](#axiosmockerrorerr-requestinfo)
   * [axios.lastReqGet](#axioslastreqget)
-  * [axios.getReqByMatchUrl](#axiosgetreqbymatchurl)
+  * [axios.getReqByMatchUrl](#axiosgetreqbymatchurlregexurl)
   * [axios.lastPromiseGet](#axioslastpromiseget)
   * [axios.reset](#axiosreset)
 * [Additional examples](#additional-examples)
@@ -239,6 +239,13 @@ most recent request, it returns the most recent request with a url that matches 
 
 ### Arguments: `regexUrl`
 The regexUrl matcher. Must contains a Regex object `Regex(/.../)`.
+
+### Usage
+
+```ts
+const req = mockAxios.getReqByMatchUrl(/resource\/\d+\/create/)
+mockAxios.mockResponse({ data: { id: 1 } }, req)
+```
 
 ## axios.lastPromiseGet()
 `lastPromiseGet` method returns a promise given when the most recent server request was made. The returned value can be used to pinpoint exact server request we wish to resolve (the value is passed as the second param of `mockResponse` or `mockError` methods).

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ In addition to standard Axios methods (`post`, `get`, `put`, `patch`, `delete`, 
 * `mockResponse` - simulates a server (web service) response
 * `mockError` - simulates a (network/server) error
 * `lastReqGet` - returns extended info about the most recent request
+* `getReqByMatchUrl` - returns extended info about the most recent request matching the given regexUrl.
+* `queue` - returns a queue with all requests received.
 * `lastPromiseGet` - returns promise created when the most recent request was made
 * `reset` - resets the Axios mock object - prepare it for the next test (typically used in `afterEach`)
 
@@ -228,6 +230,14 @@ most recent request, it returns the most recent request matching the given url o
 
 ### Arguments: `url`
 The url to be matched. Must match exactly the url passed to axios before.
+
+## axios.getReqByMatchUrl(regexUrl)
+
+`getReqByMatchUrl()` returns the same info about a specific request as `lastReqGet` (see above). Instead of returning the
+most recent request, it returns the most recent request with a url that matches the given regexUrl or `undefined` if no such request could be found.
+
+### Arguments: `regexUrl`
+The regexUrl matcher. Must contains a Regex object `Regex(/.../)`.
 
 ## axios.lastPromiseGet()
 `lastPromiseGet` method returns a promise given when the most recent server request was made. The returned value can be used to pinpoint exact server request we wish to resolve (the value is passed as the second param of `mockResponse` or `mockError` methods).

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -138,10 +138,25 @@ export interface AxiosMockAPI {
     getReqByUrl: (url: string) => AxiosMockQueueItem;
 
     /**
+     * Returns request item of the most recent request with the given regex url
+     * Returns undefined if no matching request could be found
+     *
+     * The result can then be used with @see mockResponse
+     *
+     * @param url the url of the request to be found
+     */
+    getReqByMatchUrl: (url: RegExp) => AxiosMockQueueItem;
+
+    /**
      * Removes the give request from the queue
      * @param promise
      */
     popRequest: (promise?: AxiosMockQueueItem) => AxiosMockQueueItem;
+
+    /**
+     * Return the queued requests
+     */
+    queue: () => AxiosMockQueueItem[];
 
     /**
      * Clears all of the queued requests

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -242,6 +242,17 @@ MockAxios.getReqByUrl = (url: string) => {
     return MockAxios.getReqMatching({url});
 };
 
+MockAxios.getReqByMatchUrl = (url: RegExp) => {
+    return _pending_requests
+        .slice()
+        .reverse() // reverse cloned array to return most recent req
+        .find((x: AxiosMockQueueItem) => url.test(x.url));
+};
+
+MockAxios.queue = () => {
+    return _pending_requests;
+};
+
 MockAxios.reset = () => {
     // remove all the requests
     _pending_requests.splice(0, _pending_requests.length);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -439,6 +439,26 @@ describe("MockAxios", () => {
         expect(MockAxios.options).not.toHaveBeenCalled();
     });
 
+    // queue - return the queue list
+    it("`queue` should return the queued requests", () => {
+        MockAxios.post();
+        const firstReq = MockAxios.lastReqGet();
+        MockAxios.post();
+        const secondReq = MockAxios.lastReqGet();
+
+        expect(MockAxios.queue()).toStrictEqual([firstReq, secondReq]);
+    });
+
+    // getReqByMatchUrl - return the queue list
+    it("`getReqByMatchUrl` should return the queued request with a matching regex url", () => {
+      const url = "right_url";
+      MockAxios.post(url);
+      const firstReq = MockAxios.lastReqGet();
+      MockAxios.post("wrong_url");
+
+      expect(MockAxios.getReqByMatchUrl(new RegExp('right'))).toStrictEqual(firstReq);
+    });
+
     describe("provides cancel interfaces", () => {
         it("provides axios.Cancel", () => {
             expect(MockAxios).toHaveProperty("Cancel");

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -449,7 +449,7 @@ describe("MockAxios", () => {
         expect(MockAxios.queue()).toStrictEqual([firstReq, secondReq]);
     });
 
-    // getReqByMatchUrl - return the queue list
+    // getReqByMatchUrl - return the most recent request matching the regex
     it("`getReqByMatchUrl` should return the queued request with a matching regex url", () => {
       const url = "right_url";
       MockAxios.post(url);


### PR DESCRIPTION
**Motivation:** In our project we have some react components with heavy API interactions from multiple routes. 
And use the current exposed methods `getReqByUrl()` is quite hard, because the url are dynamically built based on user interactions.

**Propose:** Expose queue() method to allow easily identify the queue size and select specific requests at a given index.
Expose getReqByMatchUrl(regex) method to allow to mock a response easily for a given part of the URL.

### Usage: 

```ts
const req = mockAxios.getReqByMatchUrl(/resource\/\d+\/create/)
mockAxios.mockResponse({ data: { ... } }, req)
```

- [x] update readme (waiting first feedback)
