### PR TITLE
Ignore case when comparing HTTP Method

### DIFF
--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -229,7 +229,7 @@ const _findReqByPredicate = (predicate: (item: AxiosMockQueueItem) => boolean) =
 }
 
 const _checkCriteria = (item: AxiosMockQueueItem, criteria: AxiosMockRequestCriteria) => {
-    if (criteria.method !== undefined && criteria.method !== item.method) {
+    if (criteria.method !== undefined && criteria.method.toLowerCase() !== item.method.toLowerCase()) {
         return false;
     }
 


### PR DESCRIPTION
Case for HTTP method shouldn't matter when finding a request. It is a gotcha that can lead to a frustrating debugging experience, even when using typescript, because mockResponseFor doesn't constrain the method property to only lowercase strings, so using `POST` for example will fail unexpectedly.