### PR TITLE
Add `isAxiosError`

### DIFF
--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -36,6 +36,7 @@ export interface AxiosAPI {
     create: jest.Mock<AxiosMockType, []>;
     interceptors: Interceptors;
     defaults: AxiosDefaults;
+    isAxiosError: (error: any) => boolean;
 }
 
 interface Cancel {

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -208,9 +208,15 @@ MockAxios.mockError = (
         return;
     }
 
-    // resolving the Promise with the given response data
+    if (error && typeof error === 'object' && error.isAxiosError === void 0) {
+        error.isAxiosError = true;
+    }
+
+    // resolving the Promise with the given error
     promise.reject(error);
 };
+
+MockAxios.isAxiosError = (payload) => (typeof payload === 'object') && (payload.isAxiosError === true);
 
 MockAxios.lastReqGet = () => {
     return _pending_requests[_pending_requests.length - 1];

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -212,6 +212,18 @@ describe("MockAxios", () => {
             expect(thenFn).not.toHaveBeenCalledWith(errorObj);
         });
 
+        it("`mockError` should mark error as an axios error", () => {
+            const thenFn = jest.fn();
+            const catchFn = jest.fn();
+            const promise = MockAxios.post();
+            promise.then(thenFn).catch(catchFn);
+
+            const errorObj = { n: "this is an error" };
+
+            MockAxios.mockError(errorObj, promise);
+            expect(MockAxios.isAxiosError(errorObj)).toBe(true)
+        });
+
         it("`mockError` should remove the promise from the queue", () => {
             MockAxios.post();
             MockAxios.mockError();


### PR DESCRIPTION
Uses the same `isAxiosError` implementation from axios proper. Modifies any
thrown errors to add an `isAxiosError` property for use by this function.

Fixes #65.