### PR TITLE
Create MockAxios.getByRegex(opts) function

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,22 +266,22 @@ The key + regex matchers. Must contain pairs of keys of the requests and a Regex
 
 * `url` that matches `/batch/`
 ```ts
-const request = mockAxios.getReqByMatchUrl({ url: /batch/ })
+const request = mockAxios.getReqByMatch({ url: /batch/ })
 ```
 
 * `data` that matches `/disciplines/`
 ```ts
-const request = mockAxios.getReqByMatchUrl({ data: /disciplines/ })
+const request = mockAxios.getReqByMatch({ data: /disciplines/ })
 ```
 
 * `config` that matches `/my_config/`
 ```ts
-const request = mockAxios.getReqByMatchUrl({ config: /my_config/ })
+const request = mockAxios.getReqByMatch({ config: /my_config/ })
 ```
 
 * `url` + `data` (multiple keys is supported ✔️)
 ```ts
-const request = mockAxios.getReqByMatchUrl({ url: /batch/, data: /disciplines/ })
+const request = mockAxios.getReqByMatch({ url: /batch/, data: /disciplines/ })
 ```
 
 ## axios.lastPromiseGet()

--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ Must contain pairs of keys and a Regex objects `RegExp(/.../)` to be tested agai
 const request = mockAxios.getReqByMatch({ url: /batch/ })
 ```
 
-* `data` that matches `/disciplines/`
+* `data` that matches `/employees/`
 ```ts
-const request = mockAxios.getReqByMatch({ data: /disciplines/ })
+const request = mockAxios.getReqByMatch({ data: /employees/ })
 ```
 
 * `config` that matches `/my_config/`
@@ -287,12 +287,12 @@ const request = mockAxios.getReqByMatch({ config: /my_config/ })
 const request = mockAxios.getReqByMatch({ method: /delete/ })
 ```
 
-* `url` that matches `/batch/` **and** `data` that matches `/disciplines/`
+* `url` that matches `/batch/` **and** `data` that matches `/employees/`
 
 > multiple keys is supported ✔️
 
 ```ts
-const request = mockAxios.getReqByMatch({ url: /batch/, data: /disciplines/ })
+const request = mockAxios.getReqByMatch({ url: /batch/, data: /employees/ })
 ```
 
 ## axios.lastPromiseGet()

--- a/README.md
+++ b/README.md
@@ -256,11 +256,14 @@ mockAxios.mockResponse({ data: { id: 1 } }, req)
 It returns the most recent request with key(s) that match(es) the given RegexUrl(s) or `undefined` if no such request could be found.
 
 ### Arguments: `opts`
+
+The keys + regexes matchers.
+
+Must contain pairs of keys and a Regex objects `RegExp(/.../)` to be tested against the requests.
+
 ```rb
 { key_a: RegExp_a, ..., key_n: RegExp_n }
 ```
-
-The key + regex matchers. Must contain pairs of keys of the requests and a Regex object `RegExp(/.../)` to be tested against.
 
 ### Usages
 
@@ -279,7 +282,15 @@ const request = mockAxios.getReqByMatch({ data: /disciplines/ })
 const request = mockAxios.getReqByMatch({ config: /my_config/ })
 ```
 
-* `url` + `data` (multiple keys is supported ✔️)
+* `method` that matches `/delete/`
+```ts
+const request = mockAxios.getReqByMatch({ method: /delete/ })
+```
+
+* `url` that matches `/batch/` **and** `data` that matches `/disciplines/`
+
+> multiple keys is supported ✔️
+
 ```ts
 const request = mockAxios.getReqByMatch({ url: /batch/, data: /disciplines/ })
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ However, if you look at the [source code](https://github.com/knee-cola/jest-mock
   * [axios.mockError](#axiosmockerrorerr-requestinfo)
   * [axios.lastReqGet](#axioslastreqget)
   * [axios.getReqByMatchUrl](#axiosgetreqbymatchurlregexurl)
-  * [axios.getReqByMatch](#axiosgetreqbymatchopts)
+  * [axios.getReqByRegex](#axiosgetreqbyregexopts)
   * [axios.lastPromiseGet](#axioslastpromiseget)
   * [axios.reset](#axiosreset)
 * [Additional examples](#additional-examples)
@@ -121,7 +121,7 @@ In addition to standard Axios methods (`post`, `get`, `put`, `patch`, `delete`, 
 * `mockError` - simulates a (network/server) error
 * `lastReqGet` - returns extended info about the most recent request
 * `getReqByMatchUrl` - returns extended info about the most recent request matching the given regexUrl.
-* `getReqByMatch` - returns extended info about the most recent request matching the given keys and regexUrls.
+* `getReqByRegex` - returns extended info about the most recent request matching the given keys and regexUrls.
 * `queue` - returns a queue with all requests received.
 * `lastPromiseGet` - returns promise created when the most recent request was made
 * `reset` - resets the Axios mock object - prepare it for the next test (typically used in `afterEach`)
@@ -249,9 +249,9 @@ const req = mockAxios.getReqByMatchUrl(/resource\/\d+\/create/)
 mockAxios.mockResponse({ data: { id: 1 } }, req)
 ```
 
-## axios.getReqByMatch(opts)
+## axios.getReqByRegex(opts)
 
-`getReqByMatch()` returns the same info about a specific request as `getReqByMatchUrl()` (see above). Instead of matching only the `url`, it's possible to match any **keys** and **RegexUrls**.
+`getReqByRegex()` returns the same info about a specific request as `getReqByMatchUrl()` (see above). Instead of matching only the `url` against a **RegexUrls**, it's possible to match **any keys** against **RegexUrls**.
 
 It returns the most recent request with key(s) that match(es) the given RegexUrl(s) or `undefined` if no such request could be found.
 
@@ -269,22 +269,22 @@ Must contain pairs of keys and a Regex objects `RegExp(/.../)` to be tested agai
 
 * `url` that matches `/batch/`
 ```ts
-const request = mockAxios.getReqByMatch({ url: /batch/ })
+const request = mockAxios.getReqByRegex({ url: /batch/ })
 ```
 
 * `data` that matches `/employees/`
 ```ts
-const request = mockAxios.getReqByMatch({ data: /employees/ })
+const request = mockAxios.getReqByRegex({ data: /employees/ })
 ```
 
 * `config` that matches `/my_config/`
 ```ts
-const request = mockAxios.getReqByMatch({ config: /my_config/ })
+const request = mockAxios.getReqByRegex({ config: /my_config/ })
 ```
 
 * `method` that matches `/delete/`
 ```ts
-const request = mockAxios.getReqByMatch({ method: /delete/ })
+const request = mockAxios.getReqByRegex({ method: /delete/ })
 ```
 
 * `url` that matches `/batch/` **and** `data` that matches `/employees/`
@@ -292,7 +292,7 @@ const request = mockAxios.getReqByMatch({ method: /delete/ })
 > multiple keys is supported ✔️
 
 ```ts
-const request = mockAxios.getReqByMatch({ url: /batch/, data: /employees/ })
+const request = mockAxios.getReqByRegex({ url: /batch/, data: /employees/ })
 ```
 
 ## axios.lastPromiseGet()

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ However, if you look at the [source code](https://github.com/knee-cola/jest-mock
   * [axios.mockError](#axiosmockerrorerr-requestinfo)
   * [axios.lastReqGet](#axioslastreqget)
   * [axios.getReqByMatchUrl](#axiosgetreqbymatchurlregexurl)
+  * [axios.getReqByMatch](#axiosgetreqbymatchopts)
   * [axios.lastPromiseGet](#axioslastpromiseget)
   * [axios.reset](#axiosreset)
 * [Additional examples](#additional-examples)
@@ -120,6 +121,7 @@ In addition to standard Axios methods (`post`, `get`, `put`, `patch`, `delete`, 
 * `mockError` - simulates a (network/server) error
 * `lastReqGet` - returns extended info about the most recent request
 * `getReqByMatchUrl` - returns extended info about the most recent request matching the given regexUrl.
+* `getReqByMatch` - returns extended info about the most recent request matching the given keys and regexUrls.
 * `queue` - returns a queue with all requests received.
 * `lastPromiseGet` - returns promise created when the most recent request was made
 * `reset` - resets the Axios mock object - prepare it for the next test (typically used in `afterEach`)
@@ -245,6 +247,41 @@ The regexUrl matcher. Must contain a Regex object `RegExp(/.../)`.
 ```ts
 const req = mockAxios.getReqByMatchUrl(/resource\/\d+\/create/)
 mockAxios.mockResponse({ data: { id: 1 } }, req)
+```
+
+## axios.getReqByMatch(opts)
+
+`getReqByMatch()` returns the same info about a specific request as `getReqByMatchUrl()` (see above). Instead of matching only the `url`, it's possible to match any **keys** and **RegexUrls**.
+
+It returns the most recent request with key(s) that match(es) the given RegexUrl(s) or `undefined` if no such request could be found.
+
+### Arguments: `opts`
+```rb
+{ key_a: RegExp_a, ..., key_n: RegExp_n }
+```
+
+The key + regex matchers. Must contain pairs of keys of the requests and a Regex object `RegExp(/.../)` to be tested against.
+
+### Usages
+
+* `url` that matches `/batch/`
+```ts
+const request = mockAxios.getReqByMatchUrl({ url: /batch/ })
+```
+
+* `data` that matches `/disciplines/`
+```ts
+const request = mockAxios.getReqByMatchUrl({ data: /disciplines/ })
+```
+
+* `config` that matches `/my_config/`
+```ts
+const request = mockAxios.getReqByMatchUrl({ config: /my_config/ })
+```
+
+* `url` + `data` (multiple keys is supported ✔️)
+```ts
+const request = mockAxios.getReqByMatchUrl({ url: /batch/, data: /disciplines/ })
 ```
 
 ## axios.lastPromiseGet()

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -151,7 +151,7 @@ export interface AxiosMockAPI {
 
     /**
      * Returns the most recent request matching any key with the regex (e.g.: url, data, config)
-     *   Can also use multiple keys for research. For example: getReqByMatch({ url: /batch/, data: /employees/ })
+     *   Can also use multiple keys for research. For example: getReqByRegex({ url: /batch/, data: /employees/ })
      *
      * Returns undefined if no matching request could be found
      *
@@ -161,7 +161,7 @@ export interface AxiosMockAPI {
      *          key_x: The key of the request to be found
      *          RegExp_x: The RegExp to be tested against that key
      */
-    getReqByMatch: (opts: {[key in keyof AxiosMockQueueItem]+?: RegExp}) => AxiosMockQueueItem;
+    getReqByRegex: (opts: {[key in keyof AxiosMockQueueItem]+?: RegExp}) => AxiosMockQueueItem;
 
     /**
      * Removes the give request from the queue

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -161,7 +161,7 @@ export interface AxiosMockAPI {
      *          key_x: The key of the request to be found
      *          RegExp_x: The RegExp to be tested against that key
      */
-    getReqByMatch: (opts: object) => AxiosMockQueueItem;
+    getReqByMatch: (opts: {[key in keyof AxiosMockQueueItem]+?: RegExp}) => AxiosMockQueueItem;
 
     /**
      * Removes the give request from the queue

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -151,7 +151,7 @@ export interface AxiosMockAPI {
 
     /**
      * Returns the most recent request matching any key with the regex (e.g.: url, data, config)
-     *   Can also use multiple keys for research. For example: getReqByMatch({ url: /batch/, data: /disciplines/ })
+     *   Can also use multiple keys for research. For example: getReqByMatch({ url: /batch/, data: /employees/ })
      *
      * Returns undefined if no matching request could be found
      *

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -150,6 +150,20 @@ export interface AxiosMockAPI {
     getReqByMatchUrl: (url: RegExp) => AxiosMockQueueItem;
 
     /**
+     * Returns the most recent request matching any key with the regex (e.g.: url, data, config)
+     *   Can also use multiple keys for research. For example: getReqByMatch({ url: /batch/, data: /disciplines/ })
+     *
+     * Returns undefined if no matching request could be found
+     *
+     * The result can then be used with @see mockResponse
+     *
+     * @param opts { key_a: RegExp_a, ..., key_n: RegExp_n }
+     *          key_x: The key of the request to be found
+     *          RegExp_x: The RegExp to be tested against that key
+     */
+    getReqByMatch: (opts: object) => AxiosMockQueueItem;
+
+    /**
      * Removes the give request from the queue
      * @param promise
      */

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -258,6 +258,16 @@ MockAxios.getReqByMatchUrl = (url: RegExp) => {
     return _findReqByPredicate((x) => url.test(x.url));
 };
 
+MockAxios.getReqByMatch = (opts: object) => {
+    return _findReqByPredicate((x) => {
+        const keys = Object.keys(opts)
+
+        return keys.every((key) => {
+            return opts[key].test(JSON.stringify(x[key]))
+        })
+    });
+};
+
 MockAxios.queue = () => {
     return _pending_requests;
 };

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -258,7 +258,7 @@ MockAxios.getReqByMatchUrl = (url: RegExp) => {
     return _findReqByPredicate((x) => url.test(x.url));
 };
 
-MockAxios.getReqByMatch = (opts: {[key in keyof AxiosMockQueueItem]+?: RegExp}) => {
+MockAxios.getReqByRegex = (opts: {[key in keyof AxiosMockQueueItem]+?: RegExp}) => {
   return _findReqByPredicate(x => Object.entries(opts).every(([key, value]) => value.test(JSON.stringify(x[key]))));
 };
 

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -258,14 +258,8 @@ MockAxios.getReqByMatchUrl = (url: RegExp) => {
     return _findReqByPredicate((x) => url.test(x.url));
 };
 
-MockAxios.getReqByMatch = (opts: object) => {
-    return _findReqByPredicate((x) => {
-        const keys = Object.keys(opts)
-
-        return keys.every((key) => {
-            return opts[key].test(JSON.stringify(x[key]))
-        })
-    });
+MockAxios.getReqByMatch = (opts: {[key in keyof AxiosMockQueueItem]+?: RegExp}) => {
+  return _findReqByPredicate(x => Object.entries(opts).every(([key, value]) => value.test(JSON.stringify(x[key]))));
 };
 
 MockAxios.queue = () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -472,6 +472,7 @@ describe("MockAxios", () => {
     });
 
     let firstReq
+    let deleteReq
     // getReqByMatch - return the most recent request matching any key with the regex (e.g.: url, data, config)
     describe("with `getReqByMatch`", () => {
       beforeEach(() => {
@@ -479,9 +480,12 @@ describe("MockAxios", () => {
         const data = { data: "my_data_value" };
         const config = { config: "my_config_value" };
         MockAxios.post(url, data, config);
-
         firstReq = MockAxios.lastReqGet();
+
         MockAxios.post("wrong_url");
+
+        MockAxios.delete("wrong_url");
+        deleteReq = MockAxios.lastReqGet();
       })
 
       it("should return the request matching url", () => {
@@ -496,8 +500,16 @@ describe("MockAxios", () => {
         expect(MockAxios.getReqByMatch({ config: new RegExp('my_config') })).toStrictEqual(firstReq);
       });
 
+      it("should return the request matching method", () => {
+        expect(MockAxios.getReqByMatch({ method: new RegExp('delete') })).toStrictEqual(deleteReq);
+      });
+
       it("should return the request matching url and data", () => {
         expect(MockAxios.getReqByMatch({ url: new RegExp('right'), data: new RegExp('my_data') })).toStrictEqual(firstReq);
+      });
+
+      it("should return undefined matching invalid keys/values", () => {
+        expect(MockAxios.getReqByMatch({ invalid: new RegExp('invalid') })).toBeUndefined();
       });
     })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -471,6 +471,63 @@ describe("MockAxios", () => {
       expect(MockAxios.getReqByMatchUrl(new RegExp('right'))).toStrictEqual(firstReq);
     });
 
+    // const method = "post";
+    // const url = "url";
+    // const data = { data: "data" };
+    // const config = { config: "config" };
+    // const promise = MockAxios.post("url", data, config);
+
+    // getReqByMatch - return the most recent request matching any key with the regex (e.g.: url, data, config)
+    describe("with `getReqByMatch`", () => {
+      it("should return the request matching url", () => {
+        const url = "right_url";
+        const data = { data: "my_data_value" };
+        const config = { config: "my_config_value" };
+        MockAxios.post(url, data, config);
+
+        const firstReq = MockAxios.lastReqGet();
+        MockAxios.post("wrong_url");
+
+        expect(MockAxios.getReqByMatch({ url: new RegExp('right') })).toStrictEqual(firstReq);
+      });
+
+      it("should return the request matching data", () => {
+        const url = "right_url";
+        const data = { data: "my_data_value" };
+        const config = { config: "my_config_value" };
+        MockAxios.post(url, data, config);
+
+        const firstReq = MockAxios.lastReqGet();
+        MockAxios.post("wrong_url");
+
+        expect(MockAxios.getReqByMatch({ data: new RegExp('my_data') })).toStrictEqual(firstReq);
+      });
+
+      it("should return the request matching config", () => {
+        const url = "right_url";
+        const data = { data: "my_data_value" };
+        const config = { config: "my_config_value" };
+        MockAxios.post(url, data, config);
+
+        const firstReq = MockAxios.lastReqGet();
+        MockAxios.post("wrong_url");
+
+        expect(MockAxios.getReqByMatch({ config: new RegExp('my_config') })).toStrictEqual(firstReq);
+      });
+
+      it("should return the request matching url and data", () => {
+        const url = "right_url";
+        const data = { data: "my_data_value" };
+        const config = { config: "my_config_value" };
+        MockAxios.post(url, data, config);
+
+        const firstReq = MockAxios.lastReqGet();
+        MockAxios.post("wrong_url");
+
+        expect(MockAxios.getReqByMatch({ url: new RegExp('right'), data: new RegExp('my_data') })).toStrictEqual(firstReq);
+      });
+    })
+
     describe("provides cancel interfaces", () => {
         it("provides axios.Cancel", () => {
             expect(MockAxios).toHaveProperty("Cancel");

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -473,8 +473,8 @@ describe("MockAxios", () => {
 
     // getReqByRegex - return the most recent request matching any key with the regex (e.g.: url, data, config)
     describe("with `getReqByRegex`", () => {
-      let firstReq
-      let deleteReq
+      let firstReq;
+      let deleteReq;
 
       beforeEach(() => {
         const url = "right_url";

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -471,10 +471,11 @@ describe("MockAxios", () => {
       expect(MockAxios.getReqByMatchUrl(new RegExp('right'))).toStrictEqual(firstReq);
     });
 
-    let firstReq
-    let deleteReq
     // getReqByMatch - return the most recent request matching any key with the regex (e.g.: url, data, config)
     describe("with `getReqByMatch`", () => {
+      let firstReq
+      let deleteReq
+
       beforeEach(() => {
         const url = "right_url";
         const data = { data: "my_data_value" };
@@ -508,8 +509,8 @@ describe("MockAxios", () => {
         expect(MockAxios.getReqByMatch({ url: new RegExp('right'), data: new RegExp('my_data') })).toStrictEqual(firstReq);
       });
 
-      it("should return undefined matching invalid keys/values", () => {
-        expect(MockAxios.getReqByMatch({ invalid: new RegExp('invalid') })).toBeUndefined();
+      it("should return undefined matching unexistent value", () => {
+        expect(MockAxios.getReqByMatch({ url: new RegExp('undefined') })).toBeUndefined();
       });
     })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -471,8 +471,8 @@ describe("MockAxios", () => {
       expect(MockAxios.getReqByMatchUrl(new RegExp('right'))).toStrictEqual(firstReq);
     });
 
-    // getReqByMatch - return the most recent request matching any key with the regex (e.g.: url, data, config)
-    describe("with `getReqByMatch`", () => {
+    // getReqByRegex - return the most recent request matching any key with the regex (e.g.: url, data, config)
+    describe("with `getReqByRegex`", () => {
       let firstReq
       let deleteReq
 
@@ -490,27 +490,27 @@ describe("MockAxios", () => {
       })
 
       it("should return the request matching url", () => {
-        expect(MockAxios.getReqByMatch({ url: new RegExp('right') })).toStrictEqual(firstReq);
+        expect(MockAxios.getReqByRegex({ url: new RegExp('right') })).toStrictEqual(firstReq);
       });
 
       it("should return the request matching data", () => {
-        expect(MockAxios.getReqByMatch({ data: new RegExp('my_data') })).toStrictEqual(firstReq);
+        expect(MockAxios.getReqByRegex({ data: new RegExp('my_data') })).toStrictEqual(firstReq);
       });
 
       it("should return the request matching config", () => {
-        expect(MockAxios.getReqByMatch({ config: new RegExp('my_config') })).toStrictEqual(firstReq);
+        expect(MockAxios.getReqByRegex({ config: new RegExp('my_config') })).toStrictEqual(firstReq);
       });
 
       it("should return the request matching method", () => {
-        expect(MockAxios.getReqByMatch({ method: new RegExp('delete') })).toStrictEqual(deleteReq);
+        expect(MockAxios.getReqByRegex({ method: new RegExp('delete') })).toStrictEqual(deleteReq);
       });
 
       it("should return the request matching url and data", () => {
-        expect(MockAxios.getReqByMatch({ url: new RegExp('right'), data: new RegExp('my_data') })).toStrictEqual(firstReq);
+        expect(MockAxios.getReqByRegex({ url: new RegExp('right'), data: new RegExp('my_data') })).toStrictEqual(firstReq);
       });
 
       it("should return undefined matching unexistent value", () => {
-        expect(MockAxios.getReqByMatch({ url: new RegExp('undefined') })).toBeUndefined();
+        expect(MockAxios.getReqByRegex({ url: new RegExp('undefined') })).toBeUndefined();
       });
     })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -471,59 +471,32 @@ describe("MockAxios", () => {
       expect(MockAxios.getReqByMatchUrl(new RegExp('right'))).toStrictEqual(firstReq);
     });
 
-    // const method = "post";
-    // const url = "url";
-    // const data = { data: "data" };
-    // const config = { config: "config" };
-    // const promise = MockAxios.post("url", data, config);
-
+    let firstReq
     // getReqByMatch - return the most recent request matching any key with the regex (e.g.: url, data, config)
     describe("with `getReqByMatch`", () => {
-      it("should return the request matching url", () => {
+      beforeEach(() => {
         const url = "right_url";
         const data = { data: "my_data_value" };
         const config = { config: "my_config_value" };
         MockAxios.post(url, data, config);
 
-        const firstReq = MockAxios.lastReqGet();
+        firstReq = MockAxios.lastReqGet();
         MockAxios.post("wrong_url");
+      })
 
+      it("should return the request matching url", () => {
         expect(MockAxios.getReqByMatch({ url: new RegExp('right') })).toStrictEqual(firstReq);
       });
 
       it("should return the request matching data", () => {
-        const url = "right_url";
-        const data = { data: "my_data_value" };
-        const config = { config: "my_config_value" };
-        MockAxios.post(url, data, config);
-
-        const firstReq = MockAxios.lastReqGet();
-        MockAxios.post("wrong_url");
-
         expect(MockAxios.getReqByMatch({ data: new RegExp('my_data') })).toStrictEqual(firstReq);
       });
 
       it("should return the request matching config", () => {
-        const url = "right_url";
-        const data = { data: "my_data_value" };
-        const config = { config: "my_config_value" };
-        MockAxios.post(url, data, config);
-
-        const firstReq = MockAxios.lastReqGet();
-        MockAxios.post("wrong_url");
-
         expect(MockAxios.getReqByMatch({ config: new RegExp('my_config') })).toStrictEqual(firstReq);
       });
 
       it("should return the request matching url and data", () => {
-        const url = "right_url";
-        const data = { data: "my_data_value" };
-        const config = { config: "my_config_value" };
-        MockAxios.post(url, data, config);
-
-        const firstReq = MockAxios.lastReqGet();
-        MockAxios.post("wrong_url");
-
         expect(MockAxios.getReqByMatch({ url: new RegExp('right'), data: new RegExp('my_data') })).toStrictEqual(firstReq);
       });
     })


### PR DESCRIPTION
## Motivation 🧗

In our project we have API interactions from multiple routes that have the same **parts of** URL, but **different data**.

The other matches on this case were not enough to capture these requests, so I'm creating a generalized version that can access everything on the request being made (`url`, `data`, `config`, `method`, etc...) and compares it with a **Regex match**.

## Idea 💡

Expose `getReqByRegex(opts)` method to allow to mock a response easily for a given pair of request keys and regexes.

## Usage 🔨

* `url` that matches `/batch/`
```ts
const request = mockAxios.getReqByRegex({ url: /batch/ })
```

* `data` that matches `/disciplines/`
```ts
const request = mockAxios.getReqByRegex({ data: /disciplines/ })
```

* `config` that matches `/my_config/`
```ts
const request = mockAxios.getReqByRegex({ config: /my_config/ })
```

* `method` that matches `/delete/`
```ts
const request = mockAxios.getReqByRegex({ method: /delete/ })
```

* `url` that matches `/batch/` **and** `data` that matches `/disciplines/`

> multiple keys is supported ✔️

```ts
const request = mockAxios.getReqByRegex({ url: /batch/, data: /disciplines/ })
```
