### PR TITLE
add correct interceptors usage

### DIFF
--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -9,13 +9,18 @@ export interface HttpResponse {
 }
 
 interface Interceptor {
-    use: jest.Mock<number, [any?, any?]>;
+    use: jest.Mock<number, [onFulfilled?: (value: any) => any | Promise<any>, onRejected?: (error: any) => any]>;
     eject: jest.Mock<void, [number]>;
 }
 
 interface Interceptors {
     request: Interceptor;
     response: Interceptor;
+}
+
+export interface InterceptorsStack {
+    onFulfilled?(value: any): any | Promise<any>;
+    onRejected?(error: any): any;
 }
 
 interface AxiosDefaults {


### PR DESCRIPTION
When using interceptors based on context (like using the class property in the interceptor) there was a problem. 
PR should fix it

I've not added the same functionality for `request` interceptors because seems like it useless