### PR TITLE
fix: add missing post on mock headers

### DIFF
--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -137,6 +137,7 @@ MockAxios.interceptors = {
 MockAxios.defaults = {
     headers: {
         common: [],
+        post: {},
     },
 };
 


### PR DESCRIPTION
Fix for https://github.com/knee-cola/jest-mock-axios/issues/88