### PR TITLE
Support requestHandler for new requests.

### DIFF
--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -25,6 +25,8 @@ export interface InterceptorsStack {
     onRejected?(error: any): any;
 }
 
+export type RequestHandler = (req: AxiosMockQueueItem) => void;
+
 interface AxiosDefaults {
     headers: any;
 }
@@ -188,6 +190,14 @@ export interface AxiosMockAPI {
      * Clears all of the queued requests
      */
     reset: () => void;
+
+    /**
+     * Set a request handler that gets invoked every time a new request comes in
+     *   The handler is invoked with the new request item
+     * 
+     * @param handler the function to invoke with the new request item every time a new request comes in
+     */
+    requestHandler: (handler: RequestHandler) => void;
 
     Cancel: CancelStatic;
     CancelToken: CancelTokenStatic;

--- a/lib/mock-axios-types.ts
+++ b/lib/mock-axios-types.ts
@@ -197,7 +197,7 @@ export interface AxiosMockAPI {
      * 
      * @param handler the function to invoke with the new request item every time a new request comes in
      */
-    requestHandler: (handler: RequestHandler) => void;
+    useRequestHandler: (handler: RequestHandler) => void;
 
     Cancel: CancelStatic;
     CancelToken: CancelTokenStatic;

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -364,7 +364,7 @@ MockAxios.reset = () => {
     MockAxios.interceptors.response.clear();
 };
 
-MockAxios.requestHandler = (handler: RequestHandler) => {
+MockAxios.useRequestHandler = (handler: RequestHandler) => {
     _requestHandler = handler;
 }
 

--- a/lib/mock-axios.ts
+++ b/lib/mock-axios.ts
@@ -17,12 +17,15 @@ import {
     AxiosMockType,
     HttpResponse,
     InterceptorsStack,
+    RequestHandler,
 } from "./mock-axios-types";
 
 /** a FIFO queue of pending request */
 const _pending_requests: AxiosMockQueueItem[] = [];
 const _responseInterceptors: InterceptorsStack[] = [];
 const _requestInterceptors: InterceptorsStack[] = [];
+
+let _requestHandler: RequestHandler;
 
 const processInterceptors = (data: any, stack: InterceptorsStack[], type: keyof InterceptorsStack) => {
     return stack.map(({[type]: interceptor}) => interceptor)
@@ -62,6 +65,11 @@ const _newReq: (config?: any) => UnresolvedSynchronousPromise<any> = (config: an
     }, _requestInterceptors, 'onFulfilled');
 
     _pending_requests.push(requestConfig);
+
+    if (typeof _requestHandler === "function") {
+        _requestHandler(requestConfig);
+    }
+
     return promise;
 };
 
@@ -355,6 +363,10 @@ MockAxios.reset = () => {
     MockAxios.interceptors.request.clear();
     MockAxios.interceptors.response.clear();
 };
+
+MockAxios.requestHandler = (handler: RequestHandler) => {
+    _requestHandler = handler;
+}
 
 MockAxios.Cancel = Cancel;
 MockAxios.CancelToken = CancelToken;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,6 +2,7 @@ import {afterEach, beforeEach, describe, expect, it, jest} from '@jest/globals';
 
 import { SynchronousPromise } from "synchronous-promise";
 import MockAxios from "../lib/index";
+import { AxiosMockQueueItem } from '../lib/mock-axios-types';
 
 describe("MockAxios", () => {
     afterEach(() => {
@@ -602,4 +603,33 @@ describe("MockAxios", () => {
             expect(() => cancelToken.token.throwIfRequested()).toThrow();
         });
     });
+
+    describe("requestHandler", () => {
+        it("provides a method to set up a requestHandler", () => {
+            expect(MockAxios).toHaveProperty("requestHandler");
+        });
+
+        it("invokes the requestHandler on every incoming request", () => {
+            const requestHandler = jest.fn();
+            MockAxios.requestHandler(requestHandler);
+
+            MockAxios.get();
+            MockAxios.post();
+
+            expect(requestHandler).toHaveBeenCalledTimes(2);
+        });
+
+        it("supplies the latest queue item to the requestHandler", () => {
+            let lastRequestHanderRequest: AxiosMockQueueItem;
+
+            MockAxios.requestHandler((req: AxiosMockQueueItem) => {
+                lastRequestHanderRequest = req;
+            });
+
+            MockAxios.post();
+
+            const lastPromise: AxiosMockQueueItem = MockAxios.post();
+            expect(lastRequestHanderRequest.promise).toBe(lastPromise);
+        });
+    })
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -628,7 +628,7 @@ describe("MockAxios", () => {
 
             MockAxios.post();
 
-            const lastPromise: AxiosMockQueueItem = MockAxios.post();
+            const lastPromise = MockAxios.post();
             expect(lastRequestHanderRequest.promise).toBe(lastPromise);
         });
     })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -622,7 +622,7 @@ describe("MockAxios", () => {
         it("supplies the latest queue item to the requestHandler", () => {
             let lastRequestHanderRequest: AxiosMockQueueItem;
 
-            MockAxios.requestHandler((req: AxiosMockQueueItem) => {
+            MockAxios.useRequestHandler((req: AxiosMockQueueItem) => {
                 lastRequestHanderRequest = req;
             });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -611,7 +611,7 @@ describe("MockAxios", () => {
 
         it("invokes the requestHandler on every incoming request", () => {
             const requestHandler = jest.fn();
-            MockAxios.requestHandler(requestHandler);
+            MockAxios.useRequestHandler(requestHandler);
 
             MockAxios.get();
             MockAxios.post();

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -606,7 +606,7 @@ describe("MockAxios", () => {
 
     describe("requestHandler", () => {
         it("provides a method to set up a requestHandler", () => {
-            expect(MockAxios).toHaveProperty("requestHandler");
+            expect(MockAxios).toHaveProperty("useRequestHandler");
         });
 
         it("invokes the requestHandler on every incoming request", () => {


### PR DESCRIPTION
This PR allows setting up a responseHandler callback function that is invoked for every new request.

Resolves issue https://github.com/knee-cola/jest-mock-axios/issues/94.

To be used like

```ts
MockAxios.useRequestHandler((req: AxiosMockQueueItem) => {
    // do something with req...
});
```